### PR TITLE
Pass 'level' to CompressorFactory

### DIFF
--- a/src/loci/formats/services/JZarrServiceImpl.java
+++ b/src/loci/formats/services/JZarrServiceImpl.java
@@ -37,7 +37,7 @@ implements ZarrService  {
   S3FileSystemStore s3fs;
   String currentId;
   Compressor zlibComp = CompressorFactory.create("zlib", "level", 8);  // 8 = compression level .. valid values 0 .. 9
-  Compressor nullComp = CompressorFactory.create("null", "level", 0);
+  Compressor nullComp = CompressorFactory.create("null");
 
   /**
    * Default constructor.


### PR DESCRIPTION
Not sure when this API changed, but looking upstream the signature is `(String id, Object...keyvalue)`.