### PR TITLE
ZarrReader: Update to support 0.4.0 datasets

### DIFF
--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -290,12 +290,12 @@ public class ZarrReader extends FormatReader {
       int resolutionTotal = 0;
       for (int i=0; i<arrayPaths.size(); i++) {
         int resolutionCount = 1;
-        if (resCounts.get(zarrRootPath+File.separator+arrayPaths.get(i)) != null) {
-          resolutionCount = resCounts.get(zarrRootPath+File.separator+arrayPaths.get(i));
+        if (resCounts.get(arrayPaths.get(i)) != null) {
+          resolutionCount = resCounts.get(arrayPaths.get(i));
         }
         int resolutionIndex= 0;
-        if (resIndexes.get(zarrRootPath+File.separator+arrayPaths.get(i)) != null) {
-          resolutionIndex = resIndexes.get(zarrRootPath+File.separator+arrayPaths.get(i));
+        if (resIndexes.get(arrayPaths.get(i)) != null) {
+          resolutionIndex = resIndexes.get(arrayPaths.get(i));
         }
 
         CoreMetadata ms = new CoreMetadata();
@@ -495,9 +495,9 @@ public class ZarrReader extends FormatReader {
         String scalePath = (String) multiScale.get("path");
         int numRes = multiscalePaths.size();
         if (i == 0) {
-          resCounts.put(path+File.separator+scalePath, numRes);
+          resCounts.put(scalePath, numRes);
         }
-        resIndexes.put(path+File.separator+scalePath, i);
+        resIndexes.put(scalePath, i);
         ArrayList<String> list = resSeries.get(resCounts.size() - 1);
         list.add(key.isEmpty() ? scalePath : key + File.separator + scalePath);
         resSeries.put(resCounts.size() - 1, list);

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -694,7 +694,9 @@ public class ZarrReader extends FormatReader {
       File folder = new File(zarrRootPath);
       Collection<File> libs = FileUtils.listFiles(folder, null, true);
       for (File file : libs) {
-        usedFiles.add(file.getAbsolutePath());
+        if (!file.isDirectory()) {
+          usedFiles.add(file.getAbsolutePath());
+        }
       }
     }
     else {

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -414,7 +414,7 @@ public class ZarrReader extends FormatReader {
       for (int row = 0; row < h; row++) {
         int base = row * w * bpp;
         for (int i = 0; i < w; i++) {
-          DataTools.unpackBytes(data[(row * w) + i + x], buf, base + 2 * i, 2, little);
+          DataTools.unpackBytes(data[(row * w) + i], buf, base + 2 * i, 2, little);
         }
       }
     }
@@ -423,7 +423,7 @@ public class ZarrReader extends FormatReader {
       for (int row = 0; row < h; row++) {
         int base = row * w * bpp;
         for (int i = 0; i < w; i++) {
-          DataTools.unpackBytes(data[(row * w) + i + x], buf, base + 4 * i, 4, little);
+          DataTools.unpackBytes(data[(row * w) + i], buf, base + 4 * i, 4, little);
         }
       }
     }
@@ -432,7 +432,7 @@ public class ZarrReader extends FormatReader {
       for (int row = 0; row < h; row++) {
         int base = row * w * bpp;
         for (int i = 0; i < w; i++) {
-          int value = Float.floatToIntBits(data[(row * w) + i + x]);
+          int value = Float.floatToIntBits(data[(row * w) + i]);
           DataTools.unpackBytes(value, buf, base + 4 * i, 4, little);
         }
       }
@@ -442,7 +442,7 @@ public class ZarrReader extends FormatReader {
       for (int row = 0; row < h; row++) {
         int base = row * w * bpp;
         for (int i = 0; i < w; i++) {
-          long value = Double.doubleToLongBits(data[(row * w) + i + x]);
+          long value = Double.doubleToLongBits(data[(row * w) + i]);
           DataTools.unpackBytes(value, buf, base + 8 * i, 8, little);
         }
       }

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -84,6 +84,14 @@ public class ZarrReader extends FormatReader {
     domains = new String[] {FormatTools.UNKNOWN_DOMAIN};
   }
 
+  /* @see loci.formats.IFormatReader#getRequiredDirectories(String[]) */
+  @Override
+  public int getRequiredDirectories(String[] files)
+    throws FormatException, IOException
+  {
+    return 1;
+  }
+
   /* @see loci.formats.IFormatReader#isThisType(String, boolean) */
   @Override
   public boolean isThisType(String name, boolean open) {


### PR DESCRIPTION
Some minor changes to support metadata from 0.3.0 based on https://ngff.openmicroscopy.org/latest/#metadata
Also some handling of datasets that don't have a 5d shape in .zarray

This should support reading of datasets in 0.3.0 and backwards compatibility should be maintained. 