### PR TITLE
Extend workflow to upload built JAR as a CI artifact

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Build
         run: mvn ${{ env.maven_commands }}
       - name: Upload JAR as artifact
+        if: matrix.os == 'ubuntu-latest' && matrix.java == '1.8'
         uses: actions/upload-artifact@v2
         with:
           name: ZarrReader

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,6 +31,11 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
       - name: Build
         run: mvn ${{ env.maven_commands }}
+      - name: Upload JAR as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ZarrReader
+          path: target/*
   deploy:
     if: contains('refs/heads/main', github.ref)
     needs: build


### PR DESCRIPTION
Discussed as part of today's call re the testing of #8, this PR proposes a simple modification to the GitHub workflow to upload the JAR built under `target` as [an artifact](https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts).

While I was enabling this, I realized that the current POM packages everything as a 65 MB uber JAR. I assume this is not strictly necessary but rather a convenience. In the same spirit as https://github.com/ome/ZarrReader/pull/8#issuecomment-932234869, can we think of a simpler scenario where only this component would be packaged and could be simply dropped into either the command-line tools and/or the ImageJ/Fiji distribution?