### PR TITLE
Activate tests in maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,42 +118,15 @@
 
   </dependencies>
 
-    <properties>
+  <properties>
     <project.rootdir>${basedir}/../..</project.rootdir>
     <maven.compiler.source>1.8</maven.compiler.source>
-   <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
-<!--   <build> -->
-<!--   <sourceDirectory>${project.basedir}/src</sourceDirectory> -->
-<!--     <resources> -->
-<!--     <resource> -->
-<!--       <directory>${project.basedir}/src</directory> -->
-<!--       <excludes> -->
-<!--         <exclude>**/*.java</exclude> -->
-<!--         <exclude>**/package.html</exclude> -->
-<!--         <exclude>**/*.properties</exclude> -->
-<!--       </excludes> -->
-<!--     </resource> -->
-<!--     <resource> -->
-<!--       <directory>${project.basedir}/src</directory> -->
-<!--       <includes> -->
-<!--         <include>**/*.properties</include> -->
-<!--       </includes> -->
-<!--       <filtering>true</filtering> -->
-<!--     </resource> -->
-<!--     <resource> -->
-<!--       <directory>${project.basedir}</directory> -->
-<!--       <includes> -->
-<!--         <include>**/*.cpp</include> -->
-<!--       </includes> -->
-<!--       <filtering>true</filtering> -->
-<!--     </resource> -->
-<!--     </resources> -->
-
-<!--   </build> -->
   <build>
     <sourceDirectory>${project.basedir}/src</sourceDirectory>
+    <testSourceDirectory>${project.basedir}/src/test</testSourceDirectory>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -31,6 +31,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -459,6 +460,10 @@ public class ZarrReader extends FormatReader {
         ArrayList<String> list = resSeries.get(resCounts.size() - 1);
         list.add(key.isEmpty() ? scalePath : key + File.separator + scalePath);
         resSeries.put(resCounts.size() - 1, list);
+      }
+      List<String> multiscaleAxes = (List<String>)datasets.get("axes");
+      for (int i = 0; i < multiscaleAxes.size(); i++) {
+        String axis = (String) multiscaleAxes.get(i);
       }
     }
   }

--- a/src/test/loci/formats/utests/ZarrReaderTest.java
+++ b/src/test/loci/formats/utests/ZarrReaderTest.java
@@ -8,6 +8,7 @@ import static org.testng.AssertJUnit.assertFalse;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -64,6 +65,7 @@ public class ZarrReaderTest {
     multiscalePaths.add(multiScale2);
     multiscalePaths.add(multiScale3);
     datasets.put("datasets", multiscalePaths);
+    datasets.put("axes", Arrays.asList("t", "c", "z", "y", "x"));
     multiscales.add(datasets);
     topLevelAttributes.put("multiscales", multiscales);
     


### PR DESCRIPTION
By adding the testSourceDirectory, the `mvn test`
target can be used in intellij to run tests. This
detected an NPE on `axes` that I've fixed here
though it would be more appropriate for gh-8.