### PR TITLE
Small jar deployment

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ZarrReader
-          path: target/*
+          path: target/*.jar
   deploy:
     if: contains('refs/heads/main', github.ref)
     needs: build

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+*.iml
 target

--- a/pom.xml
+++ b/pom.xml
@@ -38,26 +38,19 @@
 
   <dependencies>
 
-
-<!--     <dependency> -->
-<!--       <groupId>org.blosc</groupId> -->
-<!--       <artifactId>jblosc</artifactId> -->
-<!--       <version>1.0.1</version> -->
-<!--     </dependency> -->
-
     <dependency>
       <groupId>com.bc.zarr</groupId>
       <artifactId>jzarr</artifactId>
       <version>0.3.3-gs-SNAPSHOT</version>
       <!-- <version>0.4-SNAPSHOT</version>-->
     </dependency>
-    
+
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-inline</artifactId>
       <version>3.7.7</version>
     </dependency>
-    
+
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
@@ -133,10 +126,14 @@
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.0.0</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
-          <appendAssemblyId>false</appendAssemblyId>
-
+          <appendAssemblyId>true</appendAssemblyId>
           <archive>
             <manifest>
               <mainClass>loci.formats.in.ZarrReader</mainClass>
@@ -150,8 +147,8 @@
             </manifestEntries>
           </archive>
           <descriptorRefs>
-          <descriptorRef>jar-with-dependencies</descriptorRef>
-        </descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,7 @@
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
+          <attach>false</attach>
           <appendAssemblyId>true</appendAssemblyId>
           <archive>
             <manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@
     <project.rootdir>${basedir}/../..</project.rootdir>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
   <build>
@@ -118,6 +119,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,6 @@
       <name>Brockmann-Consult Public Maven Repository</name>
       <url>https://nexus.senbox.net/nexus/content/groups/public/</url>
     </repository>
-    <repository>
-      <id>glencoe-jzarr</id>
-      <name>Glencoe Software JZarr Repository </name>
-      <url>https://repo.glencoesoftware.com/repository/jzarr-snapshots/</url>
-    </repository>
   </repositories>
 
   <pluginRepositories>
@@ -41,8 +36,7 @@
     <dependency>
       <groupId>com.bc.zarr</groupId>
       <artifactId>jzarr</artifactId>
-      <version>0.3.3-gs-SNAPSHOT</version>
-      <!-- <version>0.4-SNAPSHOT</version>-->
+      <version>0.3.4</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
`ome.snapshots/ome/OMEZarrReader/0.1.0-SNAPSHOT/` now has two deployments (`mvn deploy`) with these settings:

<details><summary>settings.xml</summary>

```
(base) /opt/ZarrReader $cat ~/.m2/settings.xml
<settings>
    <servers>
        <server>
            <id>ome.snapshots</id>
            <username>jamoore</username>
            <password>${env.MAVEN_PASSWORD}</password>
        </server>
    </servers>
    <profiles>
        <profile>
            <id>jamoore</id>
            <activation>
                 <activeByDefault>true</activeByDefault>
            </activation>
            <repositories>
                <repository>
                    <id>ome.snapshots</id>
                    <name>OME's Maven Repository</name>
                    <releases>
                        <enabled>false</enabled>
                        <updatePolicy>always</updatePolicy>
                        <checksumPolicy>warn</checksumPolicy>
                    </releases>
                    <snapshots>
                        <enabled>true</enabled>
                        <updatePolicy>always</updatePolicy>
                        <checksumPolicy>warn</checksumPolicy>
                    </snapshots>
                    <url>https://artifacts.openmicroscopy.org/artifactory/ome.snapshots/</url>
                    <layout>default</layout>
                </repository>
            </repositories>
        </profile>
    </profiles>
</settings>
```

</details>

The first still had the `*.jar-with-dependencies.jar` (new name) and the second no longer does thanks to the `<attach>` element in the pom.

cc: @sbesson @dgault 