### PR TITLE
Add BSD-2 license

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
   <artifactId>OMEZarrReader</artifactId>
   <version>0.1.1-SNAPSHOT</version>
 
+  <name>Implementation of Bio-Formats readers for the next-generation file formats</name>
   <inceptionYear>2020</inceptionYear>
 
   <organization>
@@ -178,7 +179,6 @@
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
           <licenseName>bsd_2</licenseName>
-          <projectName>OME-Zarr Bio-Formats reader</projectName>
         </configuration>
       </plugin>
     </plugins>

--- a/src/loci/formats/S3FileSystemStore.java
+++ b/src/loci/formats/S3FileSystemStore.java
@@ -2,7 +2,7 @@ package loci.formats;
 
 /*-
  * #%L
- * OME-Zarr Bio-Formats reader
+ * Implementation of Bio-Formats readers for the next-generation file formats
  * %%
  * Copyright (C) 2020 - 2022 Open Microscopy Environment
  * %%

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -1,11 +1,11 @@
-/*
+
+package loci.formats.in;
+
+/*-
  * #%L
- * OME Bio-Formats package for reading and converting biological file formats.
+ * Implementation of Bio-Formats readers for the next-generation file formats
  * %%
- * Copyright (C) 2020 Open Microscopy Environment:
- *   - Board of Regents of the University of Wisconsin-Madison
- *   - Glencoe Software, Inc.
- *   - University of Dundee
+ * Copyright (C) 2020 - 2022 Open Microscopy Environment
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -29,8 +29,6 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-
-package loci.formats.in;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/loci/formats/services/JZarrServiceImpl.java
+++ b/src/loci/formats/services/JZarrServiceImpl.java
@@ -2,7 +2,7 @@ package loci.formats.services;
 
 /*-
  * #%L
- * OME-Zarr Bio-Formats reader
+ * Implementation of Bio-Formats readers for the next-generation file formats
  * %%
  * Copyright (C) 2020 - 2022 Open Microscopy Environment
  * %%

--- a/src/loci/formats/services/ZarrService.java
+++ b/src/loci/formats/services/ZarrService.java
@@ -2,7 +2,7 @@ package loci.formats.services;
 
 /*-
  * #%L
- * OME-Zarr Bio-Formats reader
+ * Implementation of Bio-Formats readers for the next-generation file formats
  * %%
  * Copyright (C) 2020 - 2022 Open Microscopy Environment
  * %%

--- a/src/test/loci/formats/utests/JZarrServiceImplTest.java
+++ b/src/test/loci/formats/utests/JZarrServiceImplTest.java
@@ -2,7 +2,7 @@ package test.loci.formats.utests;
 
 /*-
  * #%L
- * OME-Zarr Bio-Formats reader
+ * Implementation of Bio-Formats readers for the next-generation file formats
  * %%
  * Copyright (C) 2020 - 2022 Open Microscopy Environment
  * %%

--- a/src/test/loci/formats/utests/ZarrReaderMock.java
+++ b/src/test/loci/formats/utests/ZarrReaderMock.java
@@ -2,7 +2,7 @@ package test.loci.formats.utests;
 
 /*-
  * #%L
- * OME-Zarr Bio-Formats reader
+ * Implementation of Bio-Formats readers for the next-generation file formats
  * %%
  * Copyright (C) 2020 - 2022 Open Microscopy Environment
  * %%

--- a/src/test/loci/formats/utests/ZarrReaderTest.java
+++ b/src/test/loci/formats/utests/ZarrReaderTest.java
@@ -2,7 +2,7 @@ package test.loci.formats.utests;
 
 /*-
  * #%L
- * OME-Zarr Bio-Formats reader
+ * Implementation of Bio-Formats readers for the next-generation file formats
  * %%
  * Copyright (C) 2020 - 2022 Open Microscopy Environment
  * %%


### PR DESCRIPTION
As we are starting to publish this repository, I reviewed the licensing. https://github.com/ome/ZarrReader/blob/4558c079ff1ae23b38b1c53156e11266bab17eb1/src/loci/formats/in/ZarrReader.java#L2-L24 is currently GPL-2 but given the description it looks like it came from a copy-n-paste of existing reader/template rather than a decision.

Alongside our recent policy for readers/writers associated with open specification (see https://github.com/ome/bioformats/pull/3700 and https://github.com/ome/bioformats/pull/3712), this proposes to distribute this reader under the permissive BSD-2 license. Included are the minimal changes to the top-level POM and the outcome of the execution of `mvn license:update-file-header`