### PR TITLE
Add standard build metadata to the JAR manifest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,13 @@
     <url>https://www.openmicroscopy.org/</url>
   </organization>
 
+  <scm>
+    <connection>scm:git:https://github.com/ome/ZarrReader</connection>
+    <developerConnection>scm:git:git@github.com:ome/ZarrReader</developerConnection>
+    <tag>HEAD</tag>
+    <url>http://github.com/ome/ZarrReader</url>
+  </scm>
+
 
   <licenses>
     <license>
@@ -134,6 +141,10 @@
     <testSourceDirectory>${project.basedir}/src/test</testSourceDirectory>
     <plugins>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>3.0.0</version>
@@ -142,6 +153,18 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <version>3.0.0</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+            </manifest>
+            <manifestEntries>
+              <Implementation-Build>${buildNumber}</Implementation-Build>
+              <Implementation-Date>${maven.build.timestamp}</Implementation-Date>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
@@ -179,6 +202,23 @@
         <artifactId>license-maven-plugin</artifactId>
         <configuration>
           <licenseName>bsd_2</licenseName>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>buildnumber-maven-plugin</artifactId>
+        <version>1.4</version>
+        <!-- Record SCM revision in manifest. -->
+        <executions>
+          <execution>
+            <phase>validate</phase>
+            <goals>
+              <goal>create</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <revisionOnScmFailure>UNKNOWN</revisionOnScmFailure>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
While working on reviewing #8, I found it hard to identify the version of the commit used to produced a deployed ZarrReader JAR.

This should add the standard build metadata to `MAVEN/MANIFEST.MF` including the commit revision, similarly to what is being done in Bio-Formats