### PR TITLE
ZarrReader: HCS validation fixes

### DIFF
--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -288,7 +288,6 @@ public class ZarrReader extends FormatReader {
           }
         }
       }
-      parsePlate(zarrRootPath, "", store);
 
       arrayPaths = new ArrayList<String>();
       arrayPaths.addAll(zarrService.getArrayKeys(zarrRootPath));
@@ -339,11 +338,14 @@ public class ZarrReader extends FormatReader {
         ms.resolutionCount = resolutionCount;
       }
     }
+
     MetadataTools.populatePixels( store, this, true );
     for (int i = 0; i < getSeriesCount(); i++) {
-      store.setImageName(arrayPaths.get(i), i);
+      store.setImageName(arrayPaths.get(seriesToCoreIndex(i)), i);
       store.setImageID(MetadataTools.createLSID("Image", i), i);
     }
+    parsePlate(zarrRootPath, "", store);
+
     setSeries(0);
   }
 
@@ -642,7 +644,14 @@ public class ZarrReader extends FormatReader {
         String site_id = MetadataTools.createLSID("WellSample", wellSamplesCount);
         store.setWellSampleID(site_id, plateIndex, wellIndex, i);
         store.setWellSampleIndex(new NonNegativeInteger(i), plateIndex, wellIndex, i);
-        String imageID = MetadataTools.createLSID("Image", wellSamplesCount);
+        String imageRefPath = "" + i;
+        if (key != null && !key.isEmpty()) {
+          imageRefPath = key + File.separator+i;
+        }
+        if (resCounts.containsKey(imageRefPath + File.separator + "0")) {
+          imageRefPath += File.separator + "0";
+        }
+        String imageID = MetadataTools.createLSID("Image", coreIndexToSeries(arrayPaths.indexOf(imageRefPath)));
         store.setWellSampleImageRef(imageID, plateIndex, wellIndex, i);
         if (acquisition != null) {
           store.setPlateAcquisitionWellSampleRef(site_id, plateIndex, (int) acquisition, i);

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -636,10 +636,10 @@ public class ZarrReader extends FormatReader {
         String well_id =  MetadataTools.createLSID("Well", wellCount);
         store.setWellID(well_id, 0, w);
         String[] parts = wellPath.split("/");
-        if (wellRow == null || wellRow.length() == 0) {
+        if (wellRow == null || wellRow.isEmpty()) {
           wellRow = parts[parts.length - 2];
         }
-        if (wellCol == null || wellCol.length() == 0) {
+        if (wellCol == null || wellCol.isEmpty()) {
           wellCol = parts[parts.length - 1];
         }
         int rowIndex = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".indexOf(wellRow.toUpperCase());

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -568,7 +568,7 @@ public class ZarrReader extends FormatReader {
           String scalePath = (String) multiScale.get("path");
           int numRes = multiscalePaths.size();
           if (i == 0) {
-            resCounts.put(scalePath, numRes);
+            resCounts.put(key.isEmpty() ? scalePath : key + File.separator + scalePath, numRes);
           }
           resIndexes.put(scalePath, i);
           ArrayList<String> list = resSeries.get(resCounts.size() - 1);
@@ -678,7 +678,7 @@ public class ZarrReader extends FormatReader {
         store.setWellSampleIndex(new NonNegativeInteger(i), plateIndex, wellIndex, i);
         String imageRefPath = "" + i;
         if (key != null && !key.isEmpty()) {
-          imageRefPath = key + File.separator+i;
+          imageRefPath = key + File.separator + i;
         }
         if (resCounts.containsKey(imageRefPath + File.separator + "0")) {
           imageRefPath += File.separator + "0";

--- a/src/test/loci/formats/utests/ZarrReaderTest.java
+++ b/src/test/loci/formats/utests/ZarrReaderTest.java
@@ -161,7 +161,7 @@ public class ZarrReaderTest {
         
         when(zarrService.readBytes(readerShape, readerOffset)).thenReturn(expectedBuf);
         when(zarrService.getPixelType()).thenReturn(0);
-        buf = new byte[1024*512];
+        buf = new byte[1024*512*4];
         buf = reader.openBytes(0, buf);
         assertEquals(expectedBuf, buf);
       } catch (FormatException | IOException e) {


### PR DESCRIPTION
This includes a number of fixes for validation issues reported in https://github.com/ome/ZarrReader/issues/22
It also includes some additional fixes for multi res HCS data discovered during testing.

To test you can run the below and verify that no validation issues are reported and that the resolution levels are properly detected:
`BF_CP=/bio-formats-build/ZarrReader/target/OMEZarrReader-0.1.3-SNAPSHOT-jar-with-dependencies.jar /bio-formats-build/bioformats/tools/showinf -nopix -noflat -omexml /uod/idr/repos/curated/unsupported/ome-ngff/0.3/idr/idr0094A/7751.zarr/.zattrs `


Fixes #22 