### PR TITLE
ZarrReader: Add support for OME-XML from bf2raw

### DIFF
--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -36,6 +36,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 
@@ -727,6 +728,8 @@ public class ZarrReader extends FormatReader {
     {
       service = new ServiceFactory().getInstance( OMEXMLService.class );
       omexmlMeta = service.createOMEXMLMetadata( xml );
+      Hashtable originalMetadata = service.getOriginalMetadata(omexmlMeta);
+      if (originalMetadata != null) metadata = originalMetadata;
     }
     catch (DependencyException | ServiceException | NullPointerException e1 )
     {

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -84,7 +84,7 @@ public class ZarrReader extends FormatReader {
   private int wellCount = 0;
   private int wellSamplesCount = 0;
   private HashMap<String, ArrayList<String>> pathArrayDimensions = new HashMap<String, ArrayList<String>>();
-
+  private boolean planesPrePopulated = false;
   private boolean hasSPW = false;
 
   public ZarrReader() {
@@ -275,7 +275,9 @@ public class ZarrReader extends FormatReader {
       ms.resolutionCount = resolutionCount;
     }
 
-    MetadataTools.populatePixels( store, this, true );
+    if (!planesPrePopulated) {
+      MetadataTools.populatePixels( store, this, true );
+    }
     for (int i = 0; i < getSeriesCount(); i++) {
       store.setImageName(arrayPaths.get(seriesToCoreIndex(i)), i);
       store.setImageID(MetadataTools.createLSID("Image", i), i);
@@ -742,6 +744,7 @@ public class ZarrReader extends FormatReader {
       omexmlMeta = service.createOMEXMLMetadata( xml );
       Hashtable originalMetadata = service.getOriginalMetadata(omexmlMeta);
       if (originalMetadata != null) metadata = originalMetadata;
+      planesPrePopulated = true;
     }
     catch (DependencyException | ServiceException | NullPointerException e1 )
     {

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -543,7 +543,9 @@ public class ZarrReader extends FormatReader {
           acqIdsIndexMap.put(acqId, a);
           store.setPlateAcquisitionID(
               MetadataTools.createLSID("PlateAcquisition", 0, acqId), 0, a);
-          store.setPlateAcquisitionMaximumFieldCount(new PositiveInteger(maximumfieldcount), 0, a);
+          if (maximumfieldcount != null) {
+            store.setPlateAcquisitionMaximumFieldCount(new PositiveInteger(maximumfieldcount), 0, a);
+          }
         }
       }
       for (int c = 0; c < columns.size(); c++) {

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -489,7 +489,7 @@ public class ZarrReader extends FormatReader {
           if (i == 0) {
             resCounts.put(key.isEmpty() ? scalePath : key + File.separator + scalePath, numRes);
           }
-          resIndexes.put(scalePath, i);
+          resIndexes.put(key.isEmpty() ? scalePath : key + File.separator + scalePath, i);
           ArrayList<String> list = resSeries.get(resCounts.size() - 1);
           list.add(key.isEmpty() ? scalePath : key + File.separator + scalePath);
           resSeries.put(resCounts.size() - 1, list);


### PR DESCRIPTION
This PR adds parsing for the METADATA.ome.xml file produced via bioformats2raw.
Currently the XML is parsed first and any conflicting data in the Zarr attributes will override the XML values.

To test this the best approach would be to take existing OME-TIFF samples, convert them using bf2raw and then compare the OME-XML output from the original to that from the ZarrReader. The ZarrReader is still currently dumping the ngff metadata as annotations, so you will see extra annotations in the converted version. 