### PR TITLE
ZarrReader: Update getUsedFiles to use the noPixels flag

### DIFF
--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -833,8 +833,11 @@ public class ZarrReader extends FormatReader {
     String zarrRootPath = currentId.substring(0, currentId.indexOf(".zarr") + 5);
     ArrayList<String> usedFiles = new ArrayList<String>();
     try (Stream<Path> paths = Files.walk(Paths.get(zarrRootPath))) {
-      paths.filter(Files::isRegularFile)
-              .forEach(path -> usedFiles.add(path.toFile().getAbsolutePath()));
+      paths.filter(Files::isRegularFile) 
+              .forEach(path -> {if (!noPixels || 
+                  (noPixels && (path.endsWith(".zgroup") || path.endsWith(".zattrs") || path.endsWith(".xml")))) 
+                usedFiles.add(path.toFile().getAbsolutePath());
+              });
     } catch (IOException e) {
       e.printStackTrace();
     }


### PR DESCRIPTION
This is an update to the getUsedFiles method to use the `noPixels` parameter, which before now had been ignored like in many other readers. With this PR calling getUsedFiles with noPixels set to true should return the metadata files for the dataset. For the ZarrReader this will be the zattrs and zgroup files along with any xml files that may also be present.