### PR TITLE
Move to dev.zarr:jzarr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,6 @@
       <name>OME Artifactory</name>
       <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>
     </repository>
-    <repository>
-      <id>bc-nexus-repo</id>
-      <name>Brockmann-Consult Public Maven Repository</name>
-      <url>https://nexus.senbox.net/nexus/content/groups/public/</url>
-    </repository>
   </repositories>
 
   <pluginRepositories>
@@ -62,9 +57,9 @@
       <version>6.10.0</version>
     </dependency>
     <dependency>
-      <groupId>com.bc.zarr</groupId>
+      <groupId>dev.zarr</groupId>
       <artifactId>jzarr</artifactId>
-      <version>0.3.4</version>
+      <version>0.3.7</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>dev.zarr</groupId>
       <artifactId>jzarr</artifactId>
-      <version>0.3.7</version>
+      <version>0.4.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
New build of the current main branch from https://github.com/bcdev/jzarr has been copied to https://github.com/zarr-developers/jzarr and the version bumped (a few times). That package is now available on Maven Centra.