### PR TITLE
Add new option to list pixels in getUsedFiles

### DIFF
--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -866,10 +866,11 @@ public class ZarrReader extends FormatReader {
     FormatTools.assertId(currentId, true, 1);
     String zarrRootPath = currentId.substring(0, currentId.indexOf(".zarr") + 5);
     ArrayList<String> usedFiles = new ArrayList<String>();
+    boolean skipPixels = noPixels || !listPixels();
     try (Stream<Path> paths = Files.walk(Paths.get(zarrRootPath), FileVisitOption.FOLLOW_LINKS)) {
       paths.filter(Files::isRegularFile) 
-      .forEach(path -> {if (!noPixels || !listPixels() || 
-          (noPixels && (path.endsWith(".zgroup") || path.endsWith(".zattrs") || path.endsWith(".xml"))))
+      .forEach(path -> {if (!skipPixels || 
+          (skipPixels && (path.endsWith(".zgroup") || path.endsWith(".zattrs") || path.endsWith(".xml"))))
         usedFiles.add(path.toFile().getAbsolutePath());
       });
     } catch (IOException e) {


### PR DESCRIPTION
This is a follow up to https://github.com/ome/ZarrReader/pull/41

As discussed, having an option to toggle if the chunk list is returned was the preffered approach. This PR reproduces the functionality of the previous noPixels effort, but also adds a new option (which can be set on MetadataOptions). The initial default is set to false, so no pixels files will be returned by default. This is for initial testing purposes and can be updated at a later date

