### PR TITLE
Bump dev.zarr:jzarr to 0.4.2

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
-          cache: 'maven'
       - name: Build
         run: mvn ${{ env.maven_commands }}
       - name: Upload JAR as artifact

--- a/pom.xml
+++ b/pom.xml
@@ -39,11 +39,6 @@
       <name>OME Artifactory</name>
       <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>
     </repository>
-    <repository>
-      <id>unidata.releases</id>
-      <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
-      <snapshots><enabled>false</enabled></snapshots>
-    </repository>
   </repositories>
 
   <pluginRepositories>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>dev.zarr</groupId>
       <artifactId>jzarr</artifactId>
-      <version>0.4.0</version>
+      <version>0.4.2</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
       <name>OME Artifactory</name>
       <url>https://artifacts.openmicroscopy.org/artifactory/maven/</url>
     </repository>
+    <repository>
+      <id>unidata.releases</id>
+      <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
+      <snapshots><enabled>false</enabled></snapshots>
+    </repository>
   </repositories>
 
   <pluginRepositories>


### PR DESCRIPTION
Downstream consumers of this reader have been failing to build it over the last few days - see https://merge-ci.openmicroscopy.org/jenkins/job/BIOFORMATS-image/372/console or https://github.com/ome/openmicroscopy/actions/runs/6666558502/job/18118363098 with

```
Error:  Failed to execute goal on project OMEZarrReader: Could not resolve dependencies for project ome:OMEZarrReader:jar:0.3.2-SNAPSHOT: Failed to collect dependencies at dev.zarr:jzarr:jar:0.4.0 -> edu.ucar:cdm-core:jar:5.3.3: Failed to read artifact descriptor for edu.ucar:cdm-core:jar:5.3.3: Could not transfer artifact edu.ucar:cdm-core:pom:5.3.3 from/to snap-repo-public (https://snap-build-server.tilaa.cloud/nexus/repository/snap-maven-public/): transfer failed for https://snap-build-server.tilaa.cloud/nexus/repository/snap-maven-public/edu/ucar/cdm-core/5.3.3/cdm-core-5.3.3.pom: PKIX path validation failed: java.security.cert.CertPathValidatorException: validity check failed: NotAfter: Fri Oct 27 10:08:03 UTC 2023 -> [Help 1]
```

The source of the issue is the expiration of the certificate of the repository declared in https://github.com/zarr-developers/jzarr/blob/d4f85aa20816a1a0137ad3fa5a5a8513fd790c6e/pom.xml#L155-L167 and used to retrieve the `netcdf` dependency of `jzarr`.
This is not specific to `zarr.dev:jzarr` as the repository was introduced in the original repository in https://github.com/bcdev/jzarr/commit/020f964fa729779f8cd07a6bd3b11e1fa2b2a0b1.

It's unclear why this repository has been chosen and whether the certificates will be fixed. As a stopgap, this commit declares the standard Unidata repository used across the rest of Bio-Formats in this consumer repository. This should allow the builds to use this repository to fetch the `netcdf` dependency.
If the problem persists, the same change could be opened against https://github.com/zarr-developers/jzarr /cc @joshmoore 