### PR TITLE
JZarr: Add jackson.core and jackson-databind to exclsions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,16 @@
       <groupId>dev.zarr</groupId>
       <artifactId>jzarr</artifactId>
       <version>0.4.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Issue was raised by e failure in https://github.com/ome/openmicroscopy/actions/runs/7209737716/job/19641326149?pr=6373

Without this PR the 2 jackson dependencies are being picked up from JZarr and are version 2.12.7:
```
[INFO] ome:OMEZarrReader:jar:0.4.1-SNAPSHOT
[INFO] +- ome:formats-api:jar:7.0.0:compile
[INFO] |  +- org.openmicroscopy:ome-common:jar:6.0.19:compile
[INFO] |  |  +- io.minio:minio:jar:5.0.2:compile
[INFO] |  |  |  +- com.google.http-client:google-http-client-xml:jar:1.20.0:compile
[INFO] |  |  |  |  +- com.google.http-client:google-http-client:jar:1.20.0:compile
[INFO] |  |  |  |  \- xpp3:xpp3:jar:1.1.4c:compile
[INFO] |  |  |  +- com.squareup.okhttp3:okhttp:jar:3.7.0:compile
[INFO] |  |  |  \- com.squareup.okio:okio:jar:1.12.0:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:compile
[INFO] |  |  +- com.esotericsoftware:kryo:jar:5.4.0:compile
[INFO] |  |  |  +- com.esotericsoftware:reflectasm:jar:1.11.9:compile
[INFO] |  |  |  \- com.esotericsoftware:minlog:jar:1.3.1:compile
[INFO] |  |  +- joda-time:joda-time:jar:2.12.2:compile
[INFO] |  |  \- com.google.guava:guava:jar:31.1-jre:compile
[INFO] |  |     +- com.google.guava:failureaccess:jar:1.0.1:compile
[INFO] |  |     +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  |     +- org.checkerframework:checker-qual:jar:3.12.0:compile
[INFO] |  |     +- com.google.errorprone:error_prone_annotations:jar:2.11.0:compile
[INFO] |  |     \- com.google.j2objc:j2objc-annotations:jar:1.3:compile
[INFO] |  +- org.openmicroscopy:ome-xml:jar:6.3.3:compile
[INFO] |  |  \- org.openmicroscopy:specification:jar:6.3.3:compile
[INFO] |  +- org.openmicroscopy:ome-codecs:jar:1.0.0:compile
[INFO] |  |  +- org.openmicroscopy:ome-jai:jar:0.1.3:compile
[INFO] |  |  \- io.airlift:aircompressor:jar:0.21:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.30:compile
[INFO] +- dev.zarr:jzarr:jar:0.4.2:compile
[INFO] |  +- edu.ucar:cdm-core:jar:5.3.3:compile
[INFO] |  |  +- edu.ucar:udunits:jar:5.3.3:compile
[INFO] |  |  +- edu.ucar:httpservices:jar:5.3.3:compile
[INFO] |  |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.9:compile
[INFO] |  |  |  |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  |  |  |  \- commons-codec:commons-codec:jar:1.11:compile
[INFO] |  |  |  \- org.apache.httpcomponents:httpmime:jar:4.5.9:compile
[INFO] |  |  +- org.jdom:jdom2:jar:2.0.6:compile
[INFO] |  |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  |  +- com.google.protobuf:protobuf-java:jar:3.9.1:compile
[INFO] |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.11:compile
[INFO] |  |  \- com.google.re2j:re2j:jar:1.3:compile
[INFO] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.12.7.1:compile
[INFO] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.12.7:compile
[INFO] |  \- org.lasersonlab:jblosc:jar:1.0.1:compile
[INFO] |     +- junit:junit:jar:4.12:compile
[INFO] |     |  \- org.hamcrest:hamcrest-core:jar:1.3:compile
[INFO] |     \- net.java.dev.jna:jna:jar:4.2.2:compile
[INFO] +- org.mockito:mockito-inline:jar:3.7.7:test
[INFO] |  \- org.mockito:mockito-core:jar:3.7.7:test
[INFO] |     +- net.bytebuddy:byte-buddy:jar:1.10.19:test
[INFO] |     +- net.bytebuddy:byte-buddy-agent:jar:1.10.19:test
[INFO] |     \- org.objenesis:objenesis:jar:3.1:compile
[INFO] +- org.testng:testng:jar:6.10:test
[INFO] |  \- com.beust:jcommander:jar:1.48:compile
[INFO] +- xalan:serializer:jar:2.7.2:runtime
[INFO] |  \- xml-apis:xml-apis:jar:1.3.04:runtime
[INFO] \- xalan:xalan:jar:2.7.2:runtime
```

With this PR in place the jackson dependencies are picked up from OME-Common and are version 2.14.2
```
[INFO] ome:OMEZarrReader:jar:0.4.1-SNAPSHOT
[INFO] +- ome:formats-api:jar:7.0.0:compile
[INFO] |  +- org.openmicroscopy:ome-common:jar:6.0.19:compile
[INFO] |  |  +- io.minio:minio:jar:5.0.2:compile
[INFO] |  |  |  +- com.google.http-client:google-http-client-xml:jar:1.20.0:compile
[INFO] |  |  |  |  +- com.google.http-client:google-http-client:jar:1.20.0:compile
[INFO] |  |  |  |  \- xpp3:xpp3:jar:1.1.4c:compile
[INFO] |  |  |  +- com.squareup.okhttp3:okhttp:jar:3.7.0:compile
[INFO] |  |  |  \- com.squareup.okio:okio:jar:1.12.0:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.14.2:compile
[INFO] |  |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.14.2:compile
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.14.2:compile
[INFO] |  |  +- com.esotericsoftware:kryo:jar:5.4.0:compile
[INFO] |  |  |  +- com.esotericsoftware:reflectasm:jar:1.11.9:compile
[INFO] |  |  |  \- com.esotericsoftware:minlog:jar:1.3.1:compile
[INFO] |  |  +- joda-time:joda-time:jar:2.12.2:compile
[INFO] |  |  \- com.google.guava:guava:jar:31.1-jre:compile
[INFO] |  |     +- com.google.guava:failureaccess:jar:1.0.1:compile
[INFO] |  |     +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  |     +- org.checkerframework:checker-qual:jar:3.12.0:compile
[INFO] |  |     +- com.google.errorprone:error_prone_annotations:jar:2.11.0:compile
[INFO] |  |     \- com.google.j2objc:j2objc-annotations:jar:1.3:compile
[INFO] |  +- org.openmicroscopy:ome-xml:jar:6.3.3:compile
[INFO] |  |  \- org.openmicroscopy:specification:jar:6.3.3:compile
[INFO] |  +- org.openmicroscopy:ome-codecs:jar:1.0.0:compile
[INFO] |  |  +- org.openmicroscopy:ome-jai:jar:0.1.3:compile
[INFO] |  |  \- io.airlift:aircompressor:jar:0.21:compile
[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.30:compile
[INFO] +- dev.zarr:jzarr:jar:0.4.2:compile
[INFO] |  +- edu.ucar:cdm-core:jar:5.3.3:compile
[INFO] |  |  +- edu.ucar:udunits:jar:5.3.3:compile
[INFO] |  |  +- edu.ucar:httpservices:jar:5.3.3:compile
[INFO] |  |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.9:compile
[INFO] |  |  |  |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  |  |  |  \- commons-codec:commons-codec:jar:1.11:compile
[INFO] |  |  |  \- org.apache.httpcomponents:httpmime:jar:4.5.9:compile
[INFO] |  |  +- org.jdom:jdom2:jar:2.0.6:compile
[INFO] |  |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  |  +- com.google.protobuf:protobuf-java:jar:3.9.1:compile
[INFO] |  |  +- org.apache.httpcomponents:httpcore:jar:4.4.11:compile
[INFO] |  |  \- com.google.re2j:re2j:jar:1.3:compile
[INFO] |  \- org.lasersonlab:jblosc:jar:1.0.1:compile
[INFO] |     +- junit:junit:jar:4.12:compile
[INFO] |     |  \- org.hamcrest:hamcrest-core:jar:1.3:compile
[INFO] |     \- net.java.dev.jna:jna:jar:4.2.2:compile
[INFO] +- org.mockito:mockito-inline:jar:3.7.7:test
[INFO] |  \- org.mockito:mockito-core:jar:3.7.7:test
[INFO] |     +- net.bytebuddy:byte-buddy:jar:1.10.19:test
[INFO] |     +- net.bytebuddy:byte-buddy-agent:jar:1.10.19:test
[INFO] |     \- org.objenesis:objenesis:jar:3.1:compile
[INFO] +- org.testng:testng:jar:6.10:test
[INFO] |  \- com.beust:jcommander:jar:1.48:compile
[INFO] +- xalan:serializer:jar:2.7.2:runtime
[INFO] |  \- xml-apis:xml-apis:jar:1.3.04:runtime
[INFO] \- xalan:xalan:jar:2.7.2:runtime
```