### PR TITLE
Update handling and parsing of acquisition metadata

### DIFF
--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -766,7 +766,7 @@ public class ZarrReader extends FormatReader {
           if (acqDescription != null) {
             store.setPlateAcquisitionDescription(acqDescription, 0, a);
           }
-          if (acqDescription != null) {
+          if (maximumfieldcount != null) {
             store.setPlateAcquisitionMaximumFieldCount(new PositiveInteger(maximumfieldcount), 0, a);
           }
           if (acqStartTime != null) {

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -82,6 +82,7 @@ import ome.xml.model.Screen;
 import ome.xml.model.StructuredAnnotations;
 import ome.xml.model.primitives.NonNegativeInteger;
 import ome.xml.model.primitives.PositiveInteger;
+import ome.xml.model.primitives.Timestamp;
 import loci.formats.services.OMEXMLService;
 import loci.formats.services.ZarrService;
 
@@ -752,13 +753,27 @@ public class ZarrReader extends FormatReader {
           Map<String, Object> acquistion = (Map<String, Object>) acquisitions.get(a);
           Integer acqId = (Integer) acquistion.get("id");
           String acqName = (String) acquistion.get("name");
-          String acqStartTime = (String) acquistion.get("starttime");
+          String acqDescription = (String) acquistion.get("description");
+          Integer acqStartTime = (Integer) acquistion.get("starttime");
+          Integer acqEndTime = (Integer) acquistion.get("endtime");
           Integer maximumfieldcount = (Integer) acquistion.get("maximumfieldcount");
           acqIdsIndexMap.put(acqId, a);
           store.setPlateAcquisitionID(
               MetadataTools.createLSID("PlateAcquisition", 0, acqId), 0, a);
-          if (maximumfieldcount != null) {
+          if (acqName != null) {
+            store.setPlateAcquisitionName(acqName, 0, a);
+          }
+          if (acqDescription != null) {
+            store.setPlateAcquisitionDescription(acqDescription, 0, a);
+          }
+          if (acqDescription != null) {
             store.setPlateAcquisitionMaximumFieldCount(new PositiveInteger(maximumfieldcount), 0, a);
+          }
+          if (acqStartTime != null) {
+            store.setPlateAcquisitionStartTime(new Timestamp(acqStartTime.toString()), 0, a);
+          }
+          if (acqEndTime != null) {
+            store.setPlateAcquisitionEndTime(new Timestamp(acqEndTime.toString()), 0, a);
           }
         }
       }


### PR DESCRIPTION
This was originally driven by an exception seen in https://github.com/IDR/idr-metadata/issues/683#issuecomment-1884665516

The stack trace is as below and is caused by attempting to cast acquisition start time to String when it should be Integer as per the spec (https://github.com/ome/ngff/blob/main/0.4/schemas/plate.schema#L35)

```
Caused by: java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.String (java.lang.Long and java.lang.String are in module java.base of loader 'bootstrap')
        at loci.formats.in.ZarrReader.parsePlate(ZarrReader.java:755)
        at loci.formats.in.ZarrReader.initFile(ZarrReader.java:353)
        at loci.formats.FormatReader.setId(FormatReader.java:1443)
        at loci.formats.ImageReader.setId(ImageReader.java:849)
        at ome.io.nio.PixelsService$3.setId(PixelsService.java:869)
        at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:650)
        at loci.formats.ChannelFiller.setId(ChannelFiller.java:234)
        at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:650)
        at loci.formats.ChannelSeparator.setId(ChannelSeparator.java:293)
        at loci.formats.ReaderWrapper.setId(ReaderWrapper.java:650)
        at loci.formats.Memoizer.setId(Memoizer.java:690)
        at ome.io.bioformats.BfPixelsWrapper.<init>(BfPixelsWrapper.java:52)
        at ome.io.bioformats.BfPixelBuffer.reader(BfPixelBuffer.java:73)
        ... 82 common frames omitted
```

When reviewing the spec for acquisition I have also added parsing for endTime and description as well as setting all of the acquisition values on the metadataStore.