### PR TITLE
Bump formats-api version to 7.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>ome</groupId>
       <artifactId>formats-api</artifactId>
-      <version>7.1.0</version>
+      <version>7.3.0</version>
     </dependency>
     <dependency>
       <groupId>dev.zarr</groupId>


### PR DESCRIPTION
Bumping Bio-Formats API to latest release version 7.3.0