### PR TITLE
Fix Issue 109

### DIFF
--- a/src/loci/formats/S3FileSystemStore.java
+++ b/src/loci/formats/S3FileSystemStore.java
@@ -33,7 +33,6 @@ import com.bc.zarr.ZarrConstants;
 import com.bc.zarr.ZarrUtils;
 import com.bc.zarr.storage.Store;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -88,8 +87,8 @@ public class S3FileSystemStore implements Store {
     }
 
     private void setupClient() {
-      String[] pathSplit = root.toString().split(File.separator);
-      String endpoint = ENDPOINT_PROTOCOL + pathSplit[1] + File.separator;
+      String[] pathSplit = root.toString().split("/");
+      String endpoint = ENDPOINT_PROTOCOL + pathSplit[1] + "/";
       try {   
         client = AmazonS3ClientBuilder.standard()
           .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, "auto"))
@@ -115,11 +114,11 @@ public class S3FileSystemStore implements Store {
     @Override
     public InputStream getInputStream(String key) throws IOException {
         // Get the base bucket name from splitting the root path and removing the prefixed protocol and end-point
-        String[] pathSplit = root.toString().split(File.separator);
+        String[] pathSplit = root.toString().split("/");
         String bucketName =  pathSplit[2];
         
         // Append the desired key onto the remaining prefix
-        String key2 = root.toString().substring(root.toString().indexOf(pathSplit[3]), root.toString().length()) + File.separator + key;
+        String key2 = root.toString().substring(root.toString().indexOf(pathSplit[3]), root.toString().length()) + "/" + key;
 
         try {   
           S3Object o = client.getObject(bucketName, key2);
@@ -201,7 +200,7 @@ public class S3FileSystemStore implements Store {
       TreeSet<String> keys = new TreeSet<String>();
 
       // Get the base bucket name from splitting the root path and removing the prefixed protocol and end-point
-      String[] pathSplit = root.toString().split(File.separator);
+      String[] pathSplit = root.toString().split("/");
       String bucketName =  pathSplit[2];
       
       // Append the desired key onto the remaining prefix

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -182,7 +182,6 @@ public class ZarrReader extends FormatReader {
     Location zarrFolder = new Location(id);
     String zarrPath = zarrFolder.getAbsolutePath();
     String zarrRootPath = zarrPath.substring(0, zarrPath.indexOf(".zarr") + 5);
-    String name = zarrRootPath.substring(zarrRootPath.lastIndexOf(File.separator)+1, zarrRootPath.length() - 5);
     Location omeMetaFile = new Location( zarrRootPath + File.separator + "OME", "METADATA.ome.xml" );
     String canonicalPath = new Location(zarrRootPath).getCanonicalPath();
 
@@ -456,7 +455,6 @@ public class ZarrReader extends FormatReader {
   @Override
   public void reopenFile() throws IOException {
     try {
-      String canonicalPath = new Location(currentId).getCanonicalPath();
       initializeZarrService();
     }
     catch (FormatException e) {
@@ -778,16 +776,6 @@ public class ZarrReader extends FormatReader {
           }
         }
       }
-      
-//      TODO: Likely remove as values unused
-//      for (int c = 0; c < columns.size(); c++) {
-//        Map<String, Object> column = (Map<String, Object>) columns.get(c);
-//        String colName = (String) column.get("name");
-//      }
-//      for (int r = 0; r < rows.size(); r++) {
-//        Map<String, Object> row = (Map<String, Object>) rows.get(r);
-//        String rowName = (String) row.get("name");
-//      }
       
       //Create empty wells for each row and column
       wellCount  = rows.size() * columns.size();

--- a/src/loci/formats/in/ZarrReader.java
+++ b/src/loci/formats/in/ZarrReader.java
@@ -111,6 +111,7 @@ public class ZarrReader extends FormatReader {
   private boolean planesPrePopulated = false;
   private boolean hasSPW = false;
   private transient int currentOpenZarr = -1;
+  private String zarrRootPath;
 
   public ZarrReader() {
     super("Zarr", "zarr");
@@ -181,7 +182,7 @@ public class ZarrReader extends FormatReader {
     final MetadataStore store = makeFilterMetadata();
     Location zarrFolder = new Location(id);
     String zarrPath = zarrFolder.getAbsolutePath();
-    String zarrRootPath = zarrPath.substring(0, zarrPath.indexOf(".zarr") + 5);
+    this.zarrRootPath = zarrPath.substring(0, zarrPath.indexOf(".zarr") + 5);
     Location omeMetaFile = new Location( zarrRootPath + File.separator + "OME", "METADATA.ome.xml" );
     String canonicalPath = new Location(zarrRootPath).getCanonicalPath();
 
@@ -463,7 +464,7 @@ public class ZarrReader extends FormatReader {
   }
 
   protected void initializeZarrService() throws IOException, FormatException {
-    zarrService = new JZarrServiceImpl(altStore());
+    zarrService = new JZarrServiceImpl(zarrRootPath);
     openZarr();
   }
 

--- a/src/loci/formats/services/JZarrServiceImpl.java
+++ b/src/loci/formats/services/JZarrServiceImpl.java
@@ -76,13 +76,7 @@ implements ZarrService  {
   public JZarrServiceImpl(String root) {
       checkClassDependency(com.bc.zarr.ZarrArray.class);
       if (root != null && (root.matches("^https?:.*") || root.matches("^s3:.*"))) {
-        String[] pathSplit = root.toString().split("/");
-        if (S3FileSystemStore.ENDPOINT_PROTOCOL.contains(pathSplit[0].toLowerCase())) {
           s3fs = new S3FileSystemStore(Paths.get(root));
-        }
-        else {
-          LOGGER.warn("Zarr Reader is not using S3FileSystemStore as this is currently for use with S3 configured with a https endpoint");
-        }
       }
   }
 

--- a/src/loci/formats/services/JZarrServiceImpl.java
+++ b/src/loci/formats/services/JZarrServiceImpl.java
@@ -76,7 +76,7 @@ implements ZarrService  {
   public JZarrServiceImpl(String root) {
       checkClassDependency(com.bc.zarr.ZarrArray.class);
       if (root != null && (root.matches("^https?:.*") || root.matches("^s3:.*"))) {
-        String[] pathSplit = root.toString().split(File.separator);
+        String[] pathSplit = root.toString().split("/");
         if (S3FileSystemStore.ENDPOINT_PROTOCOL.contains(pathSplit[0].toLowerCase())) {
           s3fs = new S3FileSystemStore(Paths.get(root));
         }

--- a/src/loci/formats/services/JZarrServiceImpl.java
+++ b/src/loci/formats/services/JZarrServiceImpl.java
@@ -32,14 +32,9 @@ import java.io.File;
  */
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.ByteOrder;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
+
 import java.nio.file.Paths;
-import java.text.MessageFormat;
 import java.util.Map;
 import java.util.Set;
 
@@ -80,7 +75,7 @@ implements ZarrService  {
    */
   public JZarrServiceImpl(String root) {
       checkClassDependency(com.bc.zarr.ZarrArray.class);
-      if (root != null && (root.toLowerCase().contains("s3:") || root.toLowerCase().contains("s3."))) {
+      if (root != null && (root.matches("^https?:.*") || root.matches("^s3:.*"))) {
         String[] pathSplit = root.toString().split(File.separator);
         if (S3FileSystemStore.ENDPOINT_PROTOCOL.contains(pathSplit[0].toLowerCase())) {
           s3fs = new S3FileSystemStore(Paths.get(root));

--- a/src/loci/formats/services/ZarrService.java
+++ b/src/loci/formats/services/ZarrService.java
@@ -36,7 +36,6 @@ import java.util.Set;
 import loci.common.services.Service;
 import loci.formats.FormatException;
 import loci.formats.meta.MetadataRetrieve;
-import loci.formats.services.ZarrService.Compression;
 
 public interface ZarrService extends Service {
   

--- a/test/loci/formats/utests/JZarrServiceImplTest.java
+++ b/test/loci/formats/utests/JZarrServiceImplTest.java
@@ -1,4 +1,4 @@
-package test.loci.formats.utests;
+package loci.formats.utests;
 
 /*-
  * #%L

--- a/test/loci/formats/utests/ZarrReaderMock.java
+++ b/test/loci/formats/utests/ZarrReaderMock.java
@@ -1,4 +1,4 @@
-package test.loci.formats.utests;
+package loci.formats.utests;
 
 /*-
  * #%L

--- a/test/loci/formats/utests/ZarrReaderTest.java
+++ b/test/loci/formats/utests/ZarrReaderTest.java
@@ -1,4 +1,4 @@
-package test.loci.formats.utests;
+package loci.formats.utests;
 
 /*-
  * #%L


### PR DESCRIPTION
This PR fixes a couple of issues noted in https://github.com/ome/ZarrReader/issues/109 .
- An object store URL doesn't necessarily have to start with s3. This PR checks for s3 and http(s).
- On several occasions File.separator was used, also when the path is actually a URL. This fails for Windows. With this PR `/` is used in case the path is a URL.
